### PR TITLE
Bug: dropIndex didn't work on migration:rollback

### DIFF
--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -74,7 +74,8 @@ class SchemaBuilder {
     options['name'] = name
     this.createIndexes.push({ keys, options })
   }
-
+  
+  // push only the name 
   dropIndex (name) {
     this.dropIndexes.push(name)
   }
@@ -86,7 +87,8 @@ class SchemaBuilder {
     }
     for (var j in this.dropIndexes) {
       var dropIndex = this.dropIndexes[j]
-      await this.collection.dropIndex(dropIndex.keys, dropIndex.options)
+      // use only index name to drop, no options
+      await this.collection.dropIndex(dropIndex)
     }
   }
 }


### PR DESCRIPTION
My Setup:
Adonis 4, MongoDB 3.4
dropIndex didn't work with adonis migration, 
I get Error of  'invalid Index name'
Lösung:
So that we only push the index name to the dropIndex Array, we need only the name as argument in the dropIndex function from mongodb