### PR TITLE
connectionString fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ $ npm i --save lucid-mongo
 ```js
 const config = {
   connection: 'mongodb',
-  connectionString: 'mongo://username:password@localhost/my_database'
   mongodb: {
     client: 'mongodb',
+    connectionString: 'mongo://username:password@localhost/my_database',
     connection: {
       host: 'localhost',
       port: 27017,

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -109,7 +109,7 @@ class Database {
       throw new CE.RuntimeException('invalid connection type')
     }
     this.databaseName = config.connection.database
-    this.connectionString = config.connection.connectionString || mongoUriBuilder(config.connection)
+    this.connectionString = config.connectionString || mongoUriBuilder(config.connection)
     this.connection = null
     this.db = null
     this._globalTrx = null

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -110,7 +110,7 @@ class Database {
       throw new CE.RuntimeException('invalid connection type')
     }
 
-    if(config.connectionString) {
+    if (config.connectionString) {
       this.connectionString = config.connectionString
       const parsedUri = new URL(this.connectionString)
       this.databaseName = (parsedUri.pathname ? parsedUri.pathname.replace(/\//g, '') : config.connection.database)

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -15,6 +15,7 @@ const CE = require('../Exceptions')
 const util = require('../../lib/util')
 const _ = require('lodash')
 const mongoUriBuilder = require('mongo-uri-builder')
+const { URL } = require('url')
 // const debug = require('debug')('mquery')
 
 const proxyHandler = {
@@ -108,8 +109,19 @@ class Database {
     if (config.client !== 'mongodb') {
       throw new CE.RuntimeException('invalid connection type')
     }
-    this.databaseName = config.connection.database
-    this.connectionString = config.connectionString || mongoUriBuilder(config.connection)
+
+    if(config.connectionString)
+    {
+      this.connectionString = config.connectionString
+      const parsedUri = new URL(this.connectionString)
+      this.databaseName = (parsedUri.pathname ? parsedUri.pathname.replace(/\//g, '') : config.connection.database)
+    }
+    else
+    {
+      this.connectionString = mongoUriBuilder(config.connection)
+      this.databaseName = config.connection.database
+    }
+
     this.connection = null
     this.db = null
     this._globalTrx = null

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -110,14 +110,11 @@ class Database {
       throw new CE.RuntimeException('invalid connection type')
     }
 
-    if(config.connectionString)
-    {
+    if(config.connectionString) {
       this.connectionString = config.connectionString
       const parsedUri = new URL(this.connectionString)
       this.databaseName = (parsedUri.pathname ? parsedUri.pathname.replace(/\//g, '') : config.connection.database)
-    }
-    else
-    {
+    } else {
       this.connectionString = mongoUriBuilder(config.connection)
       this.databaseName = config.connection.database
     }


### PR DESCRIPTION
**Issues:**

- The README says to put the _connectionString_ in two different places, one of the examples also lacked a comma.
- It seems none of the documented places were actually looked at by the Database class. In JSON selector terms, the _connectionStrings_ were listed as something you place in either `config.connectionString` or `config.mongodb.connectionString`, but the Database class was looking for it in `config.mongodb.connection.connectionString`.
- The database name in the _connectionString_ is ignored

**This PR..**

- Puts all references to the connection string at `config.mongodb.connectionString`, outside of the connection object (as to not risk interfering with _mongoUriBuilder_).
- Parses connectionString to extract the pathname instead of always assuming `config.mongodb.connection.database` is the right value. This assumes that when set, _connectionString_ is a [valid mongo URI](https://docs.mongodb.com/manual/reference/connection-string/).