### PR TITLE
Add missing "nth" Method from Lucids Vanilla.js Serializer

### DIFF
--- a/src/LucidMongo/Serializers/Vanilla.js
+++ b/src/LucidMongo/Serializers/Vanilla.js
@@ -130,7 +130,7 @@ class VanillaSerializer {
   first () {
     return _.first(this.rows)
   }
-  
+
   /**
    * Returns the row for the given index
    *

--- a/src/LucidMongo/Serializers/Vanilla.js
+++ b/src/LucidMongo/Serializers/Vanilla.js
@@ -130,6 +130,19 @@ class VanillaSerializer {
   first () {
     return _.first(this.rows)
   }
+  
+  /**
+   * Returns the row for the given index
+   *
+   * @method nth
+   *
+   * @param  {Number} index
+   *
+   * @return {Model|Null}
+   */
+  nth (index) {
+    return _.nth(this.rows, index) || null
+  }
 
   /**
    * Get last model instance


### PR DESCRIPTION
The original Vanilla_Serializer has the method nth,
which is very helpful in certain cases.

please add the missing nth - method