### PR TITLE
fix[querybuilder] reset properly select clause when paginate is called

### DIFF
--- a/src/LucidMongo/QueryBuilder/index.js
+++ b/src/LucidMongo/QueryBuilder/index.js
@@ -365,7 +365,8 @@ class QueryBuilder {
      */
     this._applyScopes()
     const collection = await this.db.getCollection(this.collection)
-    const countQuery = _.clone(this.query).select(null)
+    const countQuery = _.clone(this.query)
+    countQuery._fields = undefined
     const countByQuery = await countQuery.collection(collection).count()
     this.query.limit(limit).skip((page - 1) * limit)
     const rows = await this.query.collection(collection).find()

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -775,7 +775,7 @@ test.group('Model', (group) => {
     assert.instanceOf(users, VanillaSerializer)
     assert.deepEqual(users.pages, { perPage: 1, total: helpers.formatNumber(2), page: 1, lastPage: 2 })
     assert.equal(users.first().username, 'virk')
-    assert.notEqual(users.first().name, 'virk')
+    assert.notExists(users.first().name)
   })
 
   test('return first row from database on calling static method', async (assert) => {

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -765,6 +765,19 @@ test.group('Model', (group) => {
     assert.equal(users.first().username, 'virk')
   })
 
+  test('paginate model with select clause', async (assert) => {
+    class User extends Model {
+    }
+
+    User._bootIfNotBooted()
+    await ioc.use('Database').collection('users').insert([{ username: 'virk', name: 'virk' }, { username: 'nikk', name: 'nikk' }])
+    const users = await User.query({select: 'username'}).paginate(1, 1)
+    assert.instanceOf(users, VanillaSerializer)
+    assert.deepEqual(users.pages, { perPage: 1, total: helpers.formatNumber(2), page: 1, lastPage: 2 })
+    assert.equal(users.first().username, 'virk')
+    assert.notEqual(users.first().name, 'virk')
+  })
+
   test('return first row from database on calling static method', async (assert) => {
     class User extends Model {
     }

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -771,7 +771,7 @@ test.group('Model', (group) => {
 
     User._bootIfNotBooted()
     await ioc.use('Database').collection('users').insert([{ username: 'virk', name: 'virk' }, { username: 'nikk', name: 'nikk' }])
-    const users = await User.query({select: 'username'}).paginate(1, 1)
+    const users = await User.query({ select: 'username' }).paginate(1, 1)
     assert.instanceOf(users, VanillaSerializer)
     assert.deepEqual(users.pages, { perPage: 1, total: helpers.formatNumber(2), page: 1, lastPage: 2 })
     assert.equal(users.first().username, 'virk')


### PR DESCRIPTION
When we do a select and a paginate at the same time. 

```js
  const countQuery = _.clone(this.query).select(null)
```
the countQuery is not properly reset like this. By looking at query after this operation. We can still see the _fields property with the selected fields. As a result this errors is thrown by mquery

```
field selection and slice cannot be used with count
```
and this error is not likelly to be fixed any time soon

https://github.com/aheckmann/mquery/issues/55
