### PR TITLE
Fixed TypeError setRelated of null in first method

### DIFF
--- a/src/LucidMongo/Relations/BelongsToMany.js
+++ b/src/LucidMongo/Relations/BelongsToMany.js
@@ -547,6 +547,11 @@ class BelongsToMany extends BaseRelation {
     const pivotInstances = await this.pivotQuery().fetch()
     const foreignKeyValues = _.map(pivotInstances.rows, this.relatedForeignKey)
     const related = await this.relatedQuery.whereIn(this.relatedPrimaryKey, foreignKeyValues).first()
+    
+    if (!related) {
+      return null
+    }
+    
     const pivot = _.find(pivotInstances.rows, pivot => String(pivot[this.relatedForeignKey]) === String(related[this.relatedPrimaryKey]))
     related.setRelated('pivot', pivot)
     return related


### PR DESCRIPTION
I had this error when I tried to fetch the first relation through a BelongsToMany relationship with no result to return. My fix consists into returning null (if no result found) before trying to link the instances.

```
TypeError: Cannot read property 'setRelated' of null
  at Proxy.first (/home/richie/dev/pickaw/node_modules/lucid-mongo/src/LucidMongo/Relations/BelongsToMany.js:556:13)
```