### PR TITLE
Fixed count method: now returns 0 instead of null

### DIFF
--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -456,8 +456,8 @@ class Database {
    * @returns {Number|Array}
    * @memberof Database
    */
-  count (...args) {
-    return this.aggregate('count', null, ...args)
+  async count (...args) {
+    return (await this.aggregate('count', null, ...args)) || 0
   }
 
   /**

--- a/src/LucidMongo/QueryBuilder/index.js
+++ b/src/LucidMongo/QueryBuilder/index.js
@@ -832,8 +832,8 @@ class QueryBuilder {
    *
    * @return {Object}
    */
-  count (groupBy) {
-    return this._aggregate('count', null, groupBy)
+  async count (groupBy) {
+    return (await this._aggregate('count', null, groupBy)) || 0
   }
 
   /**

--- a/src/LucidMongo/Relations/BelongsToMany.js
+++ b/src/LucidMongo/Relations/BelongsToMany.js
@@ -561,7 +561,7 @@ class BelongsToMany extends BaseRelation {
     this._decorateQuery()
     const pivotInstances = await this.pivotQuery().fetch()
     const foreignKeyValues = _.map(pivotInstances.rows, this.relatedForeignKey)
-    return this.relatedQuery.whereIn(this.relatedPrimaryKey, foreignKeyValues).count(...args)
+    return (await this.relatedQuery.whereIn(this.relatedPrimaryKey, foreignKeyValues).count(...args)) || 0
   }
 
   /**


### PR DESCRIPTION
The basic usage of the count method does return null instead of 0 (zero) when no document corresponds to the query.

This fix allows developers to use it without encountering unexpected results &/or errors.

**Warning:** it can lead to **breaking changes** if developers (who have noticed the behavior) have chosen to test the nullity (e.g.: `==[=] null`) of its return value.