### PR TITLE
Fix/updated_at on model instance

### DIFF
--- a/src/LucidMongo/Model/index.js
+++ b/src/LucidMongo/Model/index.js
@@ -716,6 +716,8 @@ class Model extends BaseModel {
       /**
        * Set proper timestamps
        */
+      this._setUpdatedAt(this.$attributes)
+
       affected = await this.constructor
         .query()
         .where(this.constructor.primaryKey, this.primaryKeyValue)

--- a/test/unit/lucid.spec.js
+++ b/test/unit/lucid.spec.js
@@ -360,6 +360,23 @@ test.group('Model', (group) => {
     assert.isDefined(user.updated_at)
   })
 
+  test('set timestamps automatically in existing instance', async (assert) => {
+    class User extends Model {
+    }
+
+    User._bootIfNotBooted()
+    const user = new User()
+    user.username = 'virk'
+    await user.save()
+    const originalCreatedAt = user.created_at
+    const originalUpdatedAt = user.updated_at
+
+    user.username = 'zizaco'
+    await user.save()
+    assert.strictEqual(user.created_at, originalCreatedAt, 'created_at should NOT be replaced upon update')
+    assert.notStrictEqual(user.updated_at, originalUpdatedAt, 'updated_at of instance SHOULD be replaced upon update')
+  })
+
   test('do not set timestamps when columns are not defined', async (assert) => {
     class User extends Model {
       static get createdAtColumn () {


### PR DESCRIPTION
Fixes https://github.com/duyluonglc/lucid-mongo/issues/186

The bug basically is:

**Whenever updating a entity using `.save()`, the `updated_at` attribute ( [`updatedAtColumn`](https://adonisjs.com/docs/4.0/lucid#_updatedatcolumn)) of the actual instance is not properly updated.**

---------

The test scenario that was added basically ensures that whenever `save()` is called in an existing instance, the `updated_at` of it should be refreshed.

```
  ✓ set timestamps automatically in existing instance (3ms)
```

I've written the test in a way that (without the fix) will fail with the following message:

```
  ✖ set timestamps automatically in existing instance
    Assertion Error: updated_at of instance SHOULD be replaced upon update: expected { Object (_isAMomentObject, _i, ...) } to not equal { Object (_isAMomentObject, _i, ...) }
```

I hope we can see this fixed in the main branch soon :slightly_smiling_face: 