### PR TITLE
Fixed unique validation

### DIFF
--- a/src/Validator/index.js
+++ b/src/Validator/index.js
@@ -63,16 +63,25 @@ class ValidatorRules {
       /**
        * Base query to select where key=value
        */
-      const query = this.Database.collection(collection).where(fieldName || field, value)
+      const whereConditions = {
+        [fieldName || field]: value
+      }
 
       /**
        * If a ignore key and value is defined, then add a whereNot clause
        */
       if (ignoreKey && ignoreValue) {
-        query.where(ignoreKey, '>', ignoreValue)
+        if (ignoreKey == '_id') {
+          const { ObjectId } = require('mongodb')
+          whereConditions[ignoreKey] = { '$ne': new ObjectId(ignoreValue) }
+        } else {
+          whereConditions[ignoreKey] = { '$ne': ignoreValue }
+        }
       }
 
-      query
+      this.Database
+        .collection(collection)
+        .where(whereConditions)
         .find()
         .then((rows) => {
           /**

--- a/src/Validator/index.js
+++ b/src/Validator/index.js
@@ -71,11 +71,11 @@ class ValidatorRules {
        * If a ignore key and value is defined, then add a whereNot clause
        */
       if (ignoreKey && ignoreValue) {
-        if (ignoreKey == '_id') {
+        if (ignoreKey === '_id') {
           const { ObjectId } = require('mongodb')
-          whereConditions[ignoreKey] = { '$ne': new ObjectId(ignoreValue) }
+          whereConditions[ignoreKey] = { $ne: new ObjectId(ignoreValue) }
         } else {
-          whereConditions[ignoreKey] = { '$ne': ignoreValue }
+          whereConditions[ignoreKey] = { $ne: ignoreValue }
         }
       }
 


### PR DESCRIPTION
Unique validation had the wrong comparison sign and no _id detection (as described on #211) so it only worked correctly if we didn't specify the ignoreKey/ignoreField parameters.

Unfortunately, the fix was a bit trickier than what's suggested on that issue as we apparently can't chain "where" conditions (the final query would always get only the first condition).
I'm guessing this can probably have something to do with lucid-mongo overloading some methods from mquery because according to mquery's docs, we should be able to use something like:
```
(...).where(fieldName || field).eq(value).where(ignoreKey).ne(ignoreValue)
``` 
But that doesn't appear to be working here. So my solution was to dynamically build a single where query and use it just once.

Also added "_id" detection when using the ignore fields, as most of the times the ignore field will surely be the _id so we need to use mongo's ObjectId