### PR TITLE
docs: self referencing env variables in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Edit the config/auth.js file for including the serializer. For example on the ap
     password: 'password',
     expiry: '20m',
     options: {
-      secret: 'self::app.appKey'
+      secret: Env.get('APP_KEY')
     }
   },
 


### PR DESCRIPTION
Self declarations like `self::app.appKey` had been deprecated in Adonis.